### PR TITLE
Do requests using axios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+## 3.0.0 (TBD)
+
+* __Breaking:__ Replace `request` with `axios` as underlying http client.
+* __Breaking:__ Drop support for Node <8.
+
+## 2.4.0 (May 29, 2018)
+
+* Default client requests to JSON.
+
+## 2.3.0 (Apr 29, 2018)
+
+* Expose all installation data as config properties.
+
+## 2.2.0 (Apr 17, 2018)
+
+* Expose installation `locale` as instance property.
+
+## 2.1.1 (Apr 16, 2018)
+
+* Fix syntax error in Node 7.
+
+## 2.1.0 (Apr 5, 2018)
+
+* Reuse promises when doing the same call in parallel.
+
+## 2.0.0 (Apr 2, 2018)
+
+* __Breaking:__ Promises in favor of callbacks.
+* Refactor to class definitions.
+
+## 1.2.0 (Apr 23, 2017)
+
+* Support for Node 4 & 5.
+* Retry failed request to different Verisure host.
+
+## 1.1.0 (Dec 11, 2016)
+
+* Basic support for auth, installations and overview.

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ class Verisure {
       baseURL: `https://${this.host}/xbn/2/`,
       headers: options.headers || {},
     });
+
     requestOptions.headers.Host = this.host;
     if (this.token) {
       requestOptions.headers.Cookie = `vid=${this.token}`;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const request = require('request');
+const axios = require('axios');
 const striptags = require('striptags');
 
 const VerisureInstallation = require('./installation');
@@ -23,9 +23,8 @@ class Verisure {
     }
 
     const requestOptions = Object.assign(options, {
-      baseUrl: `https://${this.host}/xbn/2/`,
+      baseURL: `https://${this.host}/xbn/2/`,
       headers: options.headers || {},
-      json: typeof options.json === 'undefined' ? true : options.json,
     });
     requestOptions.headers.Host = this.host;
     if (this.token) {
@@ -38,19 +37,20 @@ class Verisure {
       return promise;
     }
 
-    promise = new Promise((resolve, reject) => {
-      request(requestOptions, (err, res, body) => {
+    promise = axios(requestOptions)
+      .then(({ data }) => {
         delete this.promises[requestRef];
-        if (err) return reject(err);
-        if (res.statusCode > 499 && !retrying) {
-          return resolve(this.client(options, true));
+        return data;
+      })
+      .catch((error) => {
+        delete this.promises[requestRef];
+
+        if (error.response && error.response.status > 499 && !retrying) {
+          return this.client(options, true);
         }
-        if (res.statusCode > 299) {
-          return reject(body);
-        }
-        return resolve(body);
+
+        return Promise.reject((error.response && error.response.data) || error);
       });
-    });
 
     this.promises[requestRef] = promise;
     return promise;
@@ -62,12 +62,12 @@ class Verisure {
 
   getToken() {
     return this.client({
-      uri: '/cookie',
+      url: '/cookie',
       headers: {
         'Content-Type': 'application/xml;charset=UTF-8',
         Authorization: `Basic ${this.buildCredientials()}`,
+        Accept: 'text/plain',
       },
-      json: null,
     }).then((body) => {
       this.token = striptags(body).trim();
       return this.token;
@@ -75,7 +75,7 @@ class Verisure {
   }
 
   getInstallations() {
-    return this.client({ uri: `/installation/search?email=${this.email}` })
+    return this.client({ url: `/installation/search?email=${this.email}` })
       .then((installations) => installations
         .map((installation) => new VerisureInstallation(installation, this.client.bind(this))));
   }

--- a/installation.js
+++ b/installation.js
@@ -9,13 +9,13 @@ class VerisureInstallation {
 
   client(options) {
     const requestOptions = Object.assign(options, {
-      uri: `/installation/${this.giid}/${options.uri}`,
+      url: `/installation/${this.giid}/${options.url}`,
     });
     return this.baseClient(requestOptions);
   }
 
   getOverview() {
-    return this.client({ uri: 'overview' });
+    return this.client({ url: 'overview' });
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "node": ">=8"
   },
   "dependencies": {
-    "request": "^2.85.0",
+    "axios": "^0.19.0",
     "striptags": "^3.0.1"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -48,13 +48,13 @@ describe('Verisure', () => {
 
     scope.get('/xbn/2/').reply(500, 'Not this one')
       .get('/xbn/2/').reply(200, 'Success');
-    verisure.client({ uri: '/' }).then((body) => {
+    verisure.client({ url: '/' }).then((body) => {
       expect(body).toBe('Success');
       expect(verisure.host).toEqual('e-api02.verisure.com');
 
       scope.get('/xbn/2/').reply(500, 'Still not this one')
         .get('/xbn/2/').reply(200, 'Success again');
-      verisure.client({ uri: '/' }).then((secondBody) => {
+      verisure.client({ url: '/' }).then((secondBody) => {
         expect(secondBody).toBe('Success again');
         expect(verisure.host).toEqual('e-api01.verisure.com');
 
@@ -65,17 +65,17 @@ describe('Verisure', () => {
 
   it('should reject on errors like timeouts etc', () => {
     scope.get('/xbn/2/').replyWithError('Oh no');
-    return expect(verisure.client({ uri: '/' })).rejects.toThrowError('Oh no');
+    return expect(verisure.client({ url: '/' })).rejects.toThrowError('Oh no');
   });
 
   it('should reject on response code higher than 299', () => {
     scope.get('/xbn/2/').reply(300, 'Doh');
-    return expect(verisure.client({ uri: '/' })).rejects.toThrowError('Doh');
+    return expect(verisure.client({ url: '/' })).rejects.toThrowError('Doh');
   });
 
   it('should make one request when invoked in paralell', () => {
     scope.get('/xbn/2/').reply(200, 'Only once');
-    const options = { uri: '/' };
+    const options = { url: '/' };
     return Promise.all([
       verisure.client(options),
       verisure.client(options),


### PR DESCRIPTION
**What's the problem?**
The request module is deprecated.

**What's changed?**
Replace request with axios.

**How can this be verified?**
Module API is changed slightly due to replacement of the underlying http client. For example, using the `uri` option to set request path will no longer work.

**Fixes:** #34 