### PR TITLE
Support new auth hosts

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "node": ">=8"
   },
   "dependencies": {
-    "axios": "^0.21.0",
-    "striptags": "^3.0.1"
+    "axios": "^0.21.0"
   },
   "devDependencies": {
     "eslint": "^6.0.1",

--- a/test.js
+++ b/test.js
@@ -3,46 +3,59 @@ const nock = require('nock');
 const Verisure = require('./index');
 
 nock.disableNetConnect();
-const scope = nock(/https:\/\/e-api0\d.verisure.com/);
+
+const scope = nock(/https:\/\/e-api0\d.verisure.com/, {
+  reqheaders: {
+    cookie: (value) => value === 'vid=myExampleToken',
+  },
+});
 
 describe('Verisure', () => {
   const verisure = new Verisure('email', 'password');
 
   it('should get token', async () => {
-    nock(/https:\/\/automation0\d.verisure.com/)
-      .get('/auth/login').replyWithFile(200, `${__dirname}/test/responses/login.json`, {
+    const authScope = nock(/https:\/\/automation0\d.verisure.com/);
+
+    // Verify retry on different host.
+    authScope.get('/auth/login').reply(500, 'Not this one');
+
+    authScope
+      .get('/auth/login')
+      .basicAuth({ user: 'email', pass: 'password' })
+      .replyWithFile(200, `${__dirname}/test/responses/login.json`, {
         'Set-Cookie': 'vid=myExampleToken; Version=1; Path=/; Domain=verisure.com; Secure;',
       });
 
-    expect.assertions(2);
-
     const token = await verisure.getToken();
 
+    expect.assertions(3);
     expect(token).toEqual('myExampleToken');
     expect(verisure.cookie).toEqual('vid=myExampleToken');
+    expect(verisure.authHost).toEqual('automation02.verisure.com');
   });
 
-  it('should get installations', () => {
+  it('should get installations', async () => {
     scope.get(`/xbn/2/installation/search?email=${verisure.email}`)
       .replyWithFile(200, `${__dirname}/test/responses/installations.json`);
 
-    return verisure.getInstallations().then((installations) => {
-      expect.assertions(7);
-      expect(installations.length).toBe(1);
+    const installations = await verisure.getInstallations();
 
-      const [installation] = installations;
-      expect(installation.giid).toBe('123456789');
-      expect(installation.locale).toBe('sv_SE');
-      expect(installation.config.locale).toBe('sv_SE');
-      expect(typeof installation.getOverview).toBe('function');
+    expect.assertions(7);
+    expect(installations.length).toBe(1);
 
-      scope.get(`/xbn/2/installation/${installation.giid}/overview`)
-        .replyWithFile(200, `${__dirname}/test/responses/overview.json`);
-      return installation.getOverview().then((overview) => {
-        expect(typeof overview).toBe('object');
-        expect(overview.armstateCompatible).toBeTruthy();
-      });
-    });
+    const [installation] = installations;
+    expect(installation.giid).toBe('123456789');
+    expect(installation.locale).toBe('sv_SE');
+    expect(installation.config.locale).toBe('sv_SE');
+    expect(typeof installation.getOverview).toBe('function');
+
+    scope.get(`/xbn/2/installation/${installation.giid}/overview`)
+      .replyWithFile(200, `${__dirname}/test/responses/overview.json`);
+
+    const overview = await installation.getOverview();
+
+    expect(typeof overview).toBe('object');
+    expect(overview.armstateCompatible).toBeTruthy();
   });
 
   it('should retry once with different host', (done) => {

--- a/test/responses/cookie.xml
+++ b/test/responses/cookie.xml
@@ -1,3 +1,0 @@
-<response>
-  <string>myExampleToken</string>
-</response>

--- a/test/responses/login.json
+++ b/test/responses/login.json
@@ -1,0 +1,6 @@
+{
+  "accessToken": "mocked-access-token",
+  "accessTokenMaxAgeSeconds": 900,
+  "refreshToken": "mocked-refresh-token",
+  "refreshTokenMaxAgeSeconds": 63071999
+}


### PR DESCRIPTION
**What's the problem?**

Verisure have introduced two new host names to be used for authentication.

**What's changed?**

Refactored client method to only deal with duplicate requests, moving retry logic to a separate method for reuse across the two sets of host names.

**How can this be verified?**

Updated tests, no API changes.

```bash
npm install "https://github.com/ptz0n/node-verisure.git#auth-hosts" --save
```