### PR TITLE
Update hostname and HTTP method for auth

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ const axios = require('axios');
 const VerisureInstallation = require('./installation');
 
 const AUTH_HOSTS = [
-  'automation01.verisure.com',
-  'automation02.verisure.com',
+  'm-api01.verisure.com',
+  'm-api02.verisure.com',
 ];
 
 const HOSTS = [
@@ -38,7 +38,11 @@ class Verisure {
       baseURL: isAuth
         ? `https://${this.authHost}/`
         : `https://${this.host}/xbn/2/`,
-      headers: options.headers || {},
+      headers: {
+        'User-Agent': 'node-verisure',
+        accept: 'application/json',
+        ...(options.headers || {}),
+      },
     };
 
     if (this.cookies) {
@@ -83,6 +87,7 @@ class Verisure {
 
   async getToken(code) {
     let authRequest = {
+      method: 'post',
       url: '/auth/login',
       auth: {
         username: this.email,

--- a/test.js
+++ b/test.js
@@ -18,13 +18,13 @@ describe('Verisure', () => {
   });
 
   it('should get token', async () => {
-    const authScope = nock(/https:\/\/automation0\d.verisure.com/);
+    const authScope = nock(/https:\/\/m-api0\d.verisure.com/);
 
     // Verify retry on different host.
-    authScope.get('/auth/login').reply(500, 'Not this one');
+    authScope.post('/auth/login').reply(500, 'Not this one');
 
     authScope
-      .get('/auth/login')
+      .post('/auth/login')
       .basicAuth({ user: 'email', pass: 'password' })
       .replyWithFile(200, `${__dirname}/test/responses/login.json`, {
         'Set-Cookie': 'vid=myExampleToken; Version=1; Path=/; Domain=verisure.com; Secure;',
@@ -35,14 +35,14 @@ describe('Verisure', () => {
     expect.assertions(3);
     expect(cookies[0]).toEqual('vid=myExampleToken');
     expect(verisure.cookies[0]).toEqual('vid=myExampleToken');
-    expect(verisure.authHost).toEqual('automation02.verisure.com');
+    expect(verisure.authHost).toEqual('m-api02.verisure.com');
   });
 
   it('should get step up token', async () => {
-    const authScope = nock(/https:\/\/automation0\d.verisure.com/);
+    const authScope = nock(/https:\/\/m-api0\d.verisure.com/);
 
     authScope
-      .get('/auth/login')
+      .post('/auth/login')
       .basicAuth({ user: 'email', pass: 'password' })
       .replyWithFile(200, `${__dirname}/test/responses/login.json`, {
         'Set-Cookie': 'vs-stepup=myStepUpToken; Version=1; Path=/; Domain=verisure.com; Secure;',


### PR DESCRIPTION
## What's the problem?

See: https://github.com/ptz0n/homebridge-verisure/issues/127

## What's changed?

Update the login request to use the new hostname and method.

## How can this be verified?

Updated tests and verified manually.