### PR TITLE
Move to automation hostnames

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,20 +2,14 @@ const axios = require('axios');
 
 const VerisureInstallation = require('./installation');
 
-const AUTH_HOSTS = [
-  'm-api01.verisure.com',
-  'm-api02.verisure.com',
-];
-
 const HOSTS = [
-  'e-api01.verisure.com',
-  'e-api02.verisure.com',
+  'automation01.verisure.com',
+  'automation02.verisure.com',
 ];
 
 class Verisure {
   constructor(email, password, cookies = []) {
     [this.host] = HOSTS;
-    [this.authHost] = AUTH_HOSTS;
     this.email = email;
     this.password = password;
     this.promises = {};
@@ -26,17 +20,13 @@ class Verisure {
     const isAuth = options.url.startsWith('/auth');
 
     if (retrying) {
-      if (isAuth) {
-        this.authHost = AUTH_HOSTS[+!AUTH_HOSTS.indexOf(this.authHost)];
-      } else {
-        this.host = HOSTS[+!HOSTS.indexOf(this.host)];
-      }
+      this.host = HOSTS[+!HOSTS.indexOf(this.host)];
     }
 
     const request = {
       ...options,
       baseURL: isAuth
-        ? `https://${this.authHost}/`
+        ? `https://${this.host}/`
         : `https://${this.host}/xbn/2/`,
       headers: {
         'User-Agent': 'node-verisure',

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ const Verisure = require('./index');
 
 nock.disableNetConnect();
 
-const scope = nock(/https:\/\/e-api0\d.verisure.com/, {
+const scope = nock(/https:\/\/automation0\d.verisure.com/, {
   reqheaders: {
     cookie: (value) => value === 'vid=myExampleToken',
   },
@@ -18,7 +18,7 @@ describe('Verisure', () => {
   });
 
   it('should get token', async () => {
-    const authScope = nock(/https:\/\/m-api0\d.verisure.com/);
+    const authScope = nock(/https:\/\/automation0\d.verisure.com/);
 
     // Verify retry on different host.
     authScope.post('/auth/login').reply(500, 'Not this one');
@@ -35,11 +35,11 @@ describe('Verisure', () => {
     expect.assertions(3);
     expect(cookies[0]).toEqual('vid=myExampleToken');
     expect(verisure.cookies[0]).toEqual('vid=myExampleToken');
-    expect(verisure.authHost).toEqual('m-api02.verisure.com');
+    expect(verisure.host).toEqual('automation02.verisure.com');
   });
 
   it('should get step up token', async () => {
-    const authScope = nock(/https:\/\/m-api0\d.verisure.com/);
+    const authScope = nock(/https:\/\/automation0\d.verisure.com/);
 
     authScope
       .post('/auth/login')
@@ -105,19 +105,19 @@ describe('Verisure', () => {
   });
 
   it('should retry once with different host', (done) => {
-    expect(verisure.host).toEqual('e-api01.verisure.com');
+    verisure.host = 'automation01.verisure.com';
 
     scope.get('/xbn/2/').reply(500, 'Not this one')
       .get('/xbn/2/').reply(200, 'Success');
     verisure.client({ url: '/' }).then((body) => {
       expect(body).toBe('Success');
-      expect(verisure.host).toEqual('e-api02.verisure.com');
+      expect(verisure.host).toEqual('automation02.verisure.com');
 
       scope.get('/xbn/2/').reply(500, 'Still not this one')
         .get('/xbn/2/').reply(200, 'Success again');
       verisure.client({ url: '/' }).then((secondBody) => {
         expect(secondBody).toBe('Success again');
-        expect(verisure.host).toEqual('e-api01.verisure.com');
+        expect(verisure.host).toEqual('automation01.verisure.com');
 
         done();
       });


### PR DESCRIPTION
**What's the problem?**

`e-api` & `m-api` hostnames no longer accessible.

**What's changed?**

Updated hostnames and removed auth specific hosts.

**How can this be verified?**

Updated tests and verified using `verisure` bin in `homebridge-verisure`.

See: https://github.com/ptz0n/homebridge-verisure/issues/150