### PR TITLE
New hostnames, auth & support GraphQL requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.0.0 (Oct 18, 2023)
+
+* __Breaking:__ Auth using all cookies.
+* __Breaking:__ GraphQL interface.
+
 ## 4.1.0 (Oct 8, 2021)
 
 * Update hostname and method for authentication.

--- a/README.md
+++ b/README.md
@@ -47,13 +47,17 @@ console.log('One-time code sent.');
 
 await verisure.getToken(code);
 
-console.log(verisure.getCookie('vid'));
+console.log(verisure.cookies);
 ```
 
-Once you retrieve the `vid` cookie, this can be used to make authenticated requests.
+Once you retrieve the cookies, these can be used to make authenticated requests.
 
 ```javascript
-const verisure = new Verisure('my@email.com', null, ['vid=myTopSecretToken']);
+const verisure = new Verisure('my@email.com', null, [
+  'vid=myTopSecretToken',
+  'vs-access=myAccessToken',
+  'vs-refresh=myRefreshToken'
+]);
 
 const installations = await verisure.getInstallations();
 ```

--- a/README.md
+++ b/README.md
@@ -25,9 +25,21 @@ const verisure = new Verisure('my@email.com', 'mysecretpassword');
 
 verisure.getToken()
   .then(() => verisure.getInstallations())
-  .then(installations => installations[0].getOverview())
-  .then((overview) => {
-    console.log('OVERVIEW:', overview);
+  .then((installations) => installations[0].client({
+    operationName: 'Broadband',
+    query: `query Broadband($giid: String!) {
+      installation(giid: $giid) {
+        broadband {
+          testDate
+          isBroadbandConnected
+          __typename
+        }
+        __typename
+      }
+    }`,
+  }))
+  .then((broadband) => {
+    console.log('BROADBAND:', broadband);
   })
   .catch((error) => {
     console.error(error);

--- a/index.js
+++ b/index.js
@@ -16,18 +16,14 @@ class Verisure {
     this.cookies = cookies;
   }
 
-  async makeRequest(options, retrying = false) {
-    const isAuth = options.url.startsWith('/auth');
-
-    if (retrying) {
+  async makeRequest(options, changeHost = false) {
+    if (changeHost) {
       this.host = HOSTS[+!HOSTS.indexOf(this.host)];
     }
 
     const request = {
       ...options,
-      baseURL: isAuth
-        ? `https://${this.host}/`
-        : `https://${this.host}/xbn/2/`,
+      baseURL: `https://${this.host}/`,
       headers: {
         'User-Agent': 'node-verisure',
         accept: 'application/json',
@@ -42,12 +38,42 @@ class Verisure {
     try {
       return await axios(request);
     } catch (error) {
-      if (error.response && error.response.status > 499 && !retrying) {
-        return this.makeRequest(options, true);
+      if (!changeHost) {
+        const { status } = error.response || {};
+
+        // Retry with a different hostname.
+        if (status > 499) {
+          return this.makeRequest(options, true);
+        }
+
+        // Cookie expired and need to be refreshed.
+        if (status === 401 && !options.refreshingCookies) {
+          await this.refreshCookies();
+          return this.makeRequest(options);
+        }
       }
 
+      // Already tried a different hostname or got HTTP 300-400.
       throw error;
     }
+  }
+
+  async refreshCookies() {
+    const { headers } = await this.makeRequest({
+      method: 'get',
+      url: '/auth/token',
+      refreshingCookies: true,
+    });
+
+    this.setCookies(headers['set-cookie']);
+  }
+
+  setCookies(cookies) {
+    this.cookies = cookies && cookies.map((cookie) => cookie.split(';')[0]);
+  }
+
+  getCookie(prefix) {
+    return this.cookies.find((cookie) => cookie.startsWith(prefix));
   }
 
   client(request) {
@@ -57,8 +83,12 @@ class Verisure {
       return promise;
     }
 
-    promise = this.makeRequest(request)
-      .then(({ data }) => {
+    promise = this.makeRequest({
+      method: 'post',
+      url: '/graphql',
+      data: request,
+    })
+      .then(({ data: { data } }) => {
         delete this.promises[requestRef];
         return data;
       })
@@ -69,10 +99,6 @@ class Verisure {
 
     this.promises[requestRef] = promise;
     return promise;
-  }
-
-  getCookie(prefix) {
-    return this.cookies.find((cookie) => cookie.startsWith(prefix));
   }
 
   async getToken(code) {
@@ -95,10 +121,7 @@ class Verisure {
     }
 
     const { headers } = await this.makeRequest(authRequest);
-
-    const cookies = headers['set-cookie'];
-
-    this.cookies = cookies && cookies.map((cookie) => cookie.split(';')[0]);
+    this.setCookies(headers['set-cookie']);
 
     if (this.getCookie('vs-stepup')) {
       // 1. Start MFA flow, request code.
@@ -111,10 +134,35 @@ class Verisure {
     return this.cookies;
   }
 
-  getInstallations() {
-    return this.client({ url: `/installation/search?email=${this.email}` })
-      .then((installations) => installations
-        .map((installation) => new VerisureInstallation(installation, this.client.bind(this))));
+  async getInstallations() {
+    const { account: { installations } } = await this.client({
+      operationName: 'fetchAllInstallations',
+      variables: { email: this.email },
+      query: `query fetchAllInstallations($email: String!){
+        account(email: $email) {
+          installations {
+            giid
+            alias
+            customerType
+            dealerId
+            subsidiary
+            pinCodeLength
+            locale
+            address {
+              street
+              city
+              postalNumber
+              __typename
+            }
+            __typename
+          }
+          __typename
+        }
+      }`,
+    });
+
+    return installations
+      .map((installation) => new VerisureInstallation(installation, this.client.bind(this)));
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -2,20 +2,14 @@ const axios = require('axios');
 
 const VerisureInstallation = require('./installation');
 
-const AUTH_HOSTS = [
-  'm-api01.verisure.com',
-  'm-api02.verisure.com',
-];
-
 const HOSTS = [
-  'e-api01.verisure.com',
-  'e-api02.verisure.com',
+  'automation01.verisure.com',
+  'automation02.verisure.com',
 ];
 
 class Verisure {
   constructor(email, password, cookies = []) {
     [this.host] = HOSTS;
-    [this.authHost] = AUTH_HOSTS;
     this.email = email;
     this.password = password;
     this.promises = {};
@@ -26,17 +20,13 @@ class Verisure {
     const isAuth = options.url.startsWith('/auth');
 
     if (retrying) {
-      if (isAuth) {
-        this.authHost = AUTH_HOSTS[+!AUTH_HOSTS.indexOf(this.authHost)];
-      } else {
-        this.host = HOSTS[+!HOSTS.indexOf(this.host)];
-      }
+      this.host = HOSTS[+!HOSTS.indexOf(this.host)];
     }
 
     const request = {
       ...options,
       baseURL: isAuth
-        ? `https://${this.authHost}/`
+        ? `https://${this.host}/`
         : `https://${this.host}/xbn/2/`,
       headers: {
         'User-Agent': 'node-verisure',

--- a/installation.js
+++ b/installation.js
@@ -7,15 +7,14 @@ class VerisureInstallation {
     this.baseClient = client;
   }
 
-  client(options) {
-    const requestOptions = Object.assign(options, {
-      url: `/installation/${this.giid}/${options.url}`,
+  client({ variables, ...options }) {
+    return this.baseClient({
+      ...options,
+      variables: {
+        giid: this.giid,
+        ...variables,
+      },
     });
-    return this.baseClient(requestOptions);
-  }
-
-  getOverview() {
-    return this.client({ url: 'overview' });
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A module for reading and changing status of Verisure devices.",
   "main": "index.js",
   "scripts": {
-    "test": "eslint *.js && jest --env=node --coverage"
+    "test": "eslint *.js && jest --coverage"
   },
   "repository": {
     "type": "git",
@@ -15,9 +15,7 @@
     "automation",
     "verisure"
   ],
-  "author": [
-    "Erik Eng"
-  ],
+  "author": "Erik Eng",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/ptz0n/node-verisure/issues"
@@ -25,6 +23,9 @@
   "homepage": "https://github.com/ptz0n/node-verisure#readme",
   "engines": {
     "node": ">=10"
+  },
+  "jest": {
+    "testEnvironment": "node"
   },
   "dependencies": {
     "axios": "^0.21.0"

--- a/test.js
+++ b/test.js
@@ -1,12 +1,18 @@
 const nock = require('nock');
 
-const Verisure = require('./index');
+const Verisure = require('.');
 
 nock.disableNetConnect();
 
+const mockedCookies = [
+  'vid=myExampleToken',
+  'vs-access=foo',
+  'vs-refresh=bar',
+];
+
 const scope = nock(/https:\/\/automation0\d.verisure.com/, {
   reqheaders: {
-    cookie: (value) => value === 'vid=myExampleToken',
+    cookie: mockedCookies.join(';'),
   },
 });
 
@@ -14,7 +20,7 @@ describe('Verisure', () => {
   const verisure = new Verisure('email', 'password');
 
   beforeEach(() => {
-    verisure.cookies = ['vid=myExampleToken'];
+    verisure.cookies = mockedCookies;
   });
 
   it('should get token', async () => {
@@ -79,67 +85,106 @@ describe('Verisure', () => {
     expect(verisure.cookies).toEqual(expectedCookies);
   });
 
+  it('should refresh cookies when expired', async () => {
+    scope
+      .get('/random/request').reply(401)
+
+      .get('/auth/token').reply(200, '', {
+        'Set-Cookie': [
+          'vid=myNewToken; Version=1; Path=/; Domain=verisure.com; Secure;',
+          'vs-access=myNewAccessToken; Version=1; Path=/; Domain=verisure.com; Secure;',
+          'vs-refresh=myNewRefreshToken; Version=1; Path=/; Domain=verisure.com; Secure;',
+        ],
+      });
+
+    nock(/https:\/\/automation0\d.verisure.com/)
+      .matchHeader('cookie', 'vid=myNewToken;vs-access=myNewAccessToken;vs-refresh=myNewRefreshToken')
+      .get('/random/request')
+      .reply(200, { some: 'response' });
+
+    const { data } = await verisure.makeRequest({
+      url: '/random/request',
+    });
+
+    const expectedCookies = [
+      'vid=myNewToken',
+      'vs-access=myNewAccessToken',
+      'vs-refresh=myNewRefreshToken',
+    ];
+
+    expect.assertions(2);
+    expect(verisure.cookies).toEqual(expectedCookies);
+    expect(data.some).toEqual('response');
+  });
+
+  it('should throw if unable to refresh cookies', () => {
+    scope
+      .post('/graphql').reply(401) // Expired cookies?
+      .get('/auth/token').reply(401); // Failed to refresh.
+
+    return expect(verisure.client({}))
+      .rejects.toThrowError('Request failed with status code 401');
+  });
+
   it('should get installations', async () => {
-    scope.get('/xbn/2/installation/search')
-      .query({ email: verisure.email })
-      .replyWithFile(200, `${__dirname}/test/responses/installations.json`);
+    scope.post('/graphql')
+      .replyWithFile(200, `${__dirname}/test/responses/fetch-all-installations.json`);
 
     const installations = await verisure.getInstallations();
 
-    expect.assertions(7);
+    expect.assertions(5);
     expect(installations.length).toBe(1);
 
     const [installation] = installations;
     expect(installation.giid).toBe('123456789');
     expect(installation.locale).toBe('sv_SE');
     expect(installation.config.locale).toBe('sv_SE');
-    expect(typeof installation.getOverview).toBe('function');
 
-    scope.get(`/xbn/2/installation/${installation.giid}/overview`)
-      .replyWithFile(200, `${__dirname}/test/responses/overview.json`);
+    scope.post('/graphql', { variables: { giid: '123456789' } })
+      .replyWithFile(200, `${__dirname}/test/responses/broadband.json`);
 
-    const overview = await installation.getOverview();
+    const broadband = await installation.client({});
 
-    expect(typeof overview).toBe('object');
-    expect(overview.armstateCompatible).toBeTruthy();
+    expect(typeof broadband).toBe('object');
   });
 
-  it('should retry once with different host', (done) => {
+  it('should retry once with different host', async () => {
+    expect.assertions(4);
     verisure.host = 'automation01.verisure.com';
+    const url = '/graphql';
 
-    scope.get('/xbn/2/').reply(500, 'Not this one')
-      .get('/xbn/2/').reply(200, 'Success');
-    verisure.client({ url: '/' }).then((body) => {
-      expect(body).toBe('Success');
-      expect(verisure.host).toEqual('automation02.verisure.com');
+    scope
+      .post(url).reply(500, 'Not this one')
+      .post(url).reply(200, { data: 'Success' });
 
-      scope.get('/xbn/2/').reply(500, 'Still not this one')
-        .get('/xbn/2/').reply(200, 'Success again');
-      verisure.client({ url: '/' }).then((secondBody) => {
-        expect(secondBody).toBe('Success again');
-        expect(verisure.host).toEqual('automation01.verisure.com');
+    const firstResponse = await verisure.client({});
+    expect(firstResponse).toBe('Success');
+    expect(verisure.host).toEqual('automation02.verisure.com');
 
-        done();
-      });
-    });
+    scope
+      .post(url).reply(500, 'Still not this one')
+      .post(url).reply(200, { data: 'Success again' });
+
+    const secondResponse = await verisure.client({});
+    expect(secondResponse).toBe('Success again');
+    expect(verisure.host).toEqual('automation01.verisure.com');
   });
 
   it('should reject on errors like timeouts etc', () => {
-    scope.get('/xbn/2/').replyWithError('Oh no');
-    return expect(verisure.client({ url: '/' })).rejects.toThrowError('Oh no');
+    scope.post('/graphql').replyWithError('Oh no');
+    return expect(verisure.client({})).rejects.toThrowError('Oh no');
   });
 
   it('should reject on response code higher than 299', () => {
-    scope.get('/xbn/2/').reply(300, 'Doh');
-    return expect(verisure.client({ url: '/' })).rejects.toThrowError('Request failed with status code 300');
+    scope.post('/graphql').reply(300, 'Doh');
+    return expect(verisure.client({})).rejects.toThrowError('Request failed with status code 300');
   });
 
   it('should make one request when invoked in paralell', () => {
-    scope.get('/xbn/2/').reply(200, 'Only once');
-    const options = { url: '/' };
+    scope.post('/graphql').reply(200, 'Only once');
     return Promise.all([
-      verisure.client(options),
-      verisure.client(options),
+      verisure.client({}),
+      verisure.client({}),
     ]);
   });
 });

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ const Verisure = require('./index');
 
 nock.disableNetConnect();
 
-const scope = nock(/https:\/\/e-api0\d.verisure.com/, {
+const scope = nock(/https:\/\/automation0\d.verisure.com/, {
   reqheaders: {
     cookie: (value) => value === 'vid=myExampleToken',
   },
@@ -18,7 +18,7 @@ describe('Verisure', () => {
   });
 
   it('should get token', async () => {
-    const authScope = nock(/https:\/\/m-api0\d.verisure.com/);
+    const authScope = nock(/https:\/\/automation0\d.verisure.com/);
 
     // Verify retry on different host.
     authScope.post('/auth/login').reply(500, 'Not this one');
@@ -35,11 +35,11 @@ describe('Verisure', () => {
     expect.assertions(3);
     expect(cookies[0]).toEqual('vid=myExampleToken');
     expect(verisure.cookies[0]).toEqual('vid=myExampleToken');
-    expect(verisure.authHost).toEqual('m-api02.verisure.com');
+    expect(verisure.host).toEqual('automation02.verisure.com');
   });
 
   it('should get step up token', async () => {
-    const authScope = nock(/https:\/\/m-api0\d.verisure.com/);
+    const authScope = nock(/https:\/\/automation0\d.verisure.com/);
 
     authScope
       .post('/auth/login')
@@ -105,19 +105,19 @@ describe('Verisure', () => {
   });
 
   it('should retry once with different host', (done) => {
-    expect(verisure.host).toEqual('e-api01.verisure.com');
+    verisure.host = 'automation01.verisure.com';
 
     scope.get('/xbn/2/').reply(500, 'Not this one')
       .get('/xbn/2/').reply(200, 'Success');
     verisure.client({ url: '/' }).then((body) => {
       expect(body).toBe('Success');
-      expect(verisure.host).toEqual('e-api02.verisure.com');
+      expect(verisure.host).toEqual('automation02.verisure.com');
 
       scope.get('/xbn/2/').reply(500, 'Still not this one')
         .get('/xbn/2/').reply(200, 'Success again');
       verisure.client({ url: '/' }).then((secondBody) => {
         expect(secondBody).toBe('Success again');
-        expect(verisure.host).toEqual('e-api01.verisure.com');
+        expect(verisure.host).toEqual('automation01.verisure.com');
 
         done();
       });

--- a/test/responses/broadband.json
+++ b/test/responses/broadband.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "installation": {
+      "broadband": {
+        "testDate": "2023-03-17T20:10:15.000Z",
+        "isBroadbandConnected": true,
+        "__typename": "Broadband"
+      },
+      "__typename": "Installation"
+    }
+  }
+}

--- a/test/responses/fetch-all-installations.json
+++ b/test/responses/fetch-all-installations.json
@@ -1,0 +1,25 @@
+{
+  "data": {
+    "account": {
+      "installations": [
+        {
+          "giid": "123456789",
+          "alias": "Sveavägen",
+          "customerType": "HOUSEHOLD",
+          "dealerId": "ASD",
+          "subsidiary": null,
+          "pinCodeLength": 4,
+          "locale": "sv_SE",
+          "address": {
+            "street": "Sveavägen 1",
+            "city": "Stockholm",
+            "postalNumber": "SE-11157",
+            "__typename": "InstallationAddress"
+          },
+          "__typename": "Installation"
+        }
+      ],
+      "__typename": "Account"
+    }
+  }
+}


### PR DESCRIPTION
**What's the problem?**

Verisure have changed hostnames, auth and deprecated the REST API.

**What's changed?**

Refactor auth and client to support refreshing cookies and send GraphQL requests to new hostnames.

**How can this be verified?**

Updated and added a few more tests.

---

See: ptz0n/homebridge-verisure#150