### PR TITLE
Throw on GraphQL errors

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -1,0 +1,12 @@
+class GraphqlError extends Error {
+  constructor(errors) {
+    super();
+    this.name = 'GraphqlException';
+    this.message = `GraphQL response contains ${errors.length} errors`;
+    this.errors = errors;
+  }
+}
+
+module.exports = {
+  GraphqlError,
+};

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 const axios = require('axios');
 
 const VerisureInstallation = require('./installation');
+const { GraphqlError } = require('./errors');
 
 const HOSTS = [
   'automation01.verisure.com',
   'automation02.verisure.com',
 ];
-
 class Verisure {
   constructor(email, password, cookies = []) {
     [this.host] = HOSTS;
@@ -88,7 +88,11 @@ class Verisure {
       url: '/graphql',
       data: request,
     })
-      .then(({ data: { data } }) => {
+      .then(({ data: { data, errors } }) => {
+        if (errors) {
+          throw new GraphqlError(errors);
+        }
+
         delete this.promises[requestRef];
         return data;
       })

--- a/test.js
+++ b/test.js
@@ -126,6 +126,17 @@ describe('Verisure', () => {
       .rejects.toThrowError('Request failed with status code 401');
   });
 
+  it('should throw if response contains errors', () => {
+    scope.post('/graphql').reply(200, {
+      errors: [{
+        message: 'Syntax Error: Expected Name, found ")".',
+      }],
+    });
+
+    return expect(verisure.client({}))
+      .rejects.toThrow('GraphQL response contains 1 errors');
+  });
+
   it('should get installations', async () => {
     scope.post('/graphql')
       .replyWithFile(200, `${__dirname}/test/responses/fetch-all-installations.json`);


### PR DESCRIPTION
**What's the problem?**

Cannot access errors in response from GraphQL request.

**What's changed?**

Throw specific error instance for access to errors in response.

**How can this be verified?**

Added test.